### PR TITLE
Main: Simple fix to build first time

### DIFF
--- a/apps/cloud-functions/tsconfig.json
+++ b/apps/cloud-functions/tsconfig.json
@@ -7,7 +7,7 @@
     "outDir": "lib",
     "sourceMap": true,
     "strict": true,
-    "target": "es2017"
+    "target": "ES2019"
   },
   "compileOnSave": true,
   "include": ["src", "admin.ts"],

--- a/apps/websocket/tsconfig.json
+++ b/apps/websocket/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["ES2015", "DOM"],
+    "lib": ["ES2019", "DOM"],
     "module": "CommonJS",
     "outDir": "./dist",
     "rootDir": "./src"

--- a/packages/tsconfig/react-library.json
+++ b/packages/tsconfig/react-library.json
@@ -3,7 +3,7 @@
   "display": "React Library",
   "extends": "./base.json",
   "compilerOptions": {
-    "lib": ["ES2015"],
+    "lib": ["ES2019"],
     "module": "ESNext",
     "target": "ES6",
     "jsx": "react-jsx"


### PR DESCRIPTION
Simple fix to change compiler lib from ES2015/ES2017 to ES2019 to build successfully. 


Issue:
```
cloud-functions:build: src/twitter/twitter.onCall.ts(63,21): error TS2550: Property 'fromEntries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2019' or later.

cloud-functions:build: error Command failed with exit code 2.
```

This error shows up when building the first time. Hopefully this simple changes fixes it.